### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/products-zone/index.html
+++ b/src/products-zone/index.html
@@ -1,5 +1,5 @@
 <yield>
-  <gb-list items="{ props.zone.products }">
-    <gb-product product="{ item }"></gb-product>
+  <gb-list items="{props.zone.products}">
+    <gb-product product="{item}"></gb-product>
   </gb-list>
 </yield>

--- a/src/rich-content-zone/index.html
+++ b/src/rich-content-zone/index.html
@@ -1,1 +1,1 @@
-<gb-raw content="{ props.zone.content }"></gb-raw>
+<gb-raw content="{props.zone.content}"></gb-raw>

--- a/src/template/index.html
+++ b/src/template/index.html
@@ -1,5 +1,5 @@
-<div if="{ state.isActive }">
+<div if="{state.isActive}">
   <yield>
-    <div each="{ zone, name in state.zones }" data-is="gb-{ zone.type.replace('_', '-') }-zone" zone="{ zone }"></div>
+    <div each="{zone, name in state.zones}" data-is="gb-{zone.type.replace('_', '-')}-zone" zone="{zone}"></div>
   </yield>
 </div>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.